### PR TITLE
fix: validate DID JWT issuer binding

### DIFF
--- a/wallet-sdk/src/main/java/io/arcblock/walletkit/bean/DIDTokenBody.kt
+++ b/wallet-sdk/src/main/java/io/arcblock/walletkit/bean/DIDTokenBody.kt
@@ -2,9 +2,9 @@ package io.arcblock.walletkit.bean
 
 import io.arcblock.walletkit.did.DidAuthUtils
 import io.arcblock.walletkit.did.DidType
-import io.arcblock.walletkit.did.DidUtils
 import io.arcblock.walletkit.did.IdGenerator
 import io.arcblock.walletkit.utils.Base58Btc
+import io.arcblock.walletkit.utils.address
 
 class DIDTokenBody(
   var action: String,
@@ -29,9 +29,9 @@ class DIDTokenBody(
    * check pk is matched with iss and signature is correct
    */
   fun verifyJWTDID(token: String, pk: ByteArray): Boolean {
-    return (IdGenerator.pk2did(
-      pk, DidType.getDidTypeByAddress(iss)
-    ) != iss) && DidAuthUtils.verifyJWTSig(token, pk, DidUtils.decodeSignTypeByPk(pk).name)
+    val didType = DidType.getDidTypeByAddress(iss)
+    return (IdGenerator.pk2did(pk, didType) == iss.address()) &&
+      DidAuthUtils.verifyJWTSig(token, pk, didType.keyType.name)
   }
 
   /**

--- a/wallet-sdk/src/main/java/io/arcblock/walletkit/bean/DIDTokenResponse.kt
+++ b/wallet-sdk/src/main/java/io/arcblock/walletkit/bean/DIDTokenResponse.kt
@@ -3,9 +3,9 @@ package io.arcblock.walletkit.bean
 import com.google.gson.JsonArray
 import io.arcblock.walletkit.did.DidAuthUtils
 import io.arcblock.walletkit.did.DidType
-import io.arcblock.walletkit.did.DidUtils
 import io.arcblock.walletkit.did.IdGenerator
 import io.arcblock.walletkit.utils.Base58Btc
+import io.arcblock.walletkit.utils.address
 
 class DIDTokenResponse(
   var action: String,
@@ -30,9 +30,9 @@ class DIDTokenResponse(
    * check pk is matched with iss and signature is correct
    */
   fun verifyJWTDID(token: String, pk: ByteArray): Boolean {
-    return (IdGenerator.pk2did(
-      pk, DidType.getDidTypeByAddress(iss)
-    ) != iss) && DidAuthUtils.verifyJWTSig(token, pk, DidUtils.decodeSignTypeByPk(pk).name)
+    val didType = DidType.getDidTypeByAddress(iss)
+    return (IdGenerator.pk2did(pk, didType) == iss.address()) &&
+      DidAuthUtils.verifyJWTSig(token, pk, didType.keyType.name)
   }
 
   /**

--- a/wallet-sdk/src/test/java/io/arcblock/walletkit/did/DidAuthUtilsTest.kt
+++ b/wallet-sdk/src/test/java/io/arcblock/walletkit/did/DidAuthUtilsTest.kt
@@ -1,11 +1,14 @@
 package io.arcblock.walletkit.did
 
+import com.google.common.io.BaseEncoding
 import io.arcblock.walletkit.bean.AppInfo
+import io.arcblock.walletkit.bean.IClaim
 import io.arcblock.walletkit.bean.MetaInfo
 import io.arcblock.walletkit.bean.ProfileClaim
 import io.arcblock.walletkit.bean.WalletInfo
 import io.arcblock.walletkit.utils.decodeB64
 import io.arcblock.walletkit.utils.encodeB58
+import org.junit.Assert
 import org.junit.Test
 
 /**
@@ -22,6 +25,51 @@ import org.junit.Test
  * Description  :
  */
 class DidAuthUtilsTest {
+
+  private val signingSk =
+    "dxX9ASBY+BTNayyTnIRC4A8QadAFi3F+GuE3+It8ltcM0h56H8xeJqTHn2w03uEfKJ801fjmeaygaIt0rHBaNg==".decodeB64()
+
+  private val otherSk = BaseEncoding.base16()
+    .decode("91F9EEA50EBCE155E6F1BAB1EB9C6D74AF3DB1D2C20A951F790E9AA28285DEF28270BBEABBB608361CBD3610A8220B66CBC8D5F82B7DDA6EB3F880D9FB2460EC")
+
+  @Test
+  fun verifyJWTDIDReturnsTrueWhenIssuerMatchesPublicKey() {
+    val wallet = WalletInfo(signingSk)
+    val token = createTestDidAuthToken(wallet)
+
+    val body = DidAuthUtils.parseJWT(token)
+
+    Assert.assertTrue(body.verifyJWTDID(token, wallet.pk))
+  }
+
+  @Test
+  fun verifyJWTDIDReturnsFalseWhenSignatureKeyDoesNotMatchIssuer() {
+    val signingWallet = WalletInfo(signingSk)
+    val issuerWallet = WalletInfo(otherSk)
+    val token = createTestDidAuthToken(
+      WalletInfo(issuerWallet.address, signingWallet.pk).let {
+        it.sk = signingSk
+        it
+      }
+    )
+
+    val body = DidAuthUtils.parseJWT(token)
+
+    Assert.assertFalse(body.verifyJWTDID(token, signingWallet.pk))
+  }
+
+  private fun createTestDidAuthToken(wallet: WalletInfo): String {
+    return DidAuthUtils.createDidAuthToken(
+      emptyArray<IClaim>(),
+      AppInfo().let {
+        it.name = "DID Auth Test"
+        it
+      },
+      "",
+      1700000000000L,
+      wallet
+    )
+  }
 
 
   @Test


### PR DESCRIPTION
## Summary
- Fix verifyJWTDID issuer/public key binding check
- Normalize did:abt issuer values to addresses before comparison
- Derive JWT signature type from issuer DID type instead of raw public key bytes
- Add positive and mismatched issuer coverage for verifyJWTDID

## Tests
- ./gradlew --no-daemon :wallet-sdk:testDebugUnitTest